### PR TITLE
mediatek: filogic: add support for ASUS RT-AX52

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-asus-rt-ax52.dts
+++ b/target/linux/mediatek/dts/mt7981b-asus-rt-ax52.dts
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+#include "mt7981.dtsi"
+/ {
+	model = "ASUS RT-AX52";
+	compatible = "asus,rt-ax52", "mediatek,mt7981";
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-override = "ubi.mtd=UBI_DEV";
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x10000000>;
+	};
+	/*aliases {
+		ethernet0 = "/ethernet@15100000/mac@0";
+		ethernet1 = "/ethernet@15100000/mac@1";
+	};
+	*/
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan24 {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5 {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+		led_system: system {
+			label = "blue:system";
+			gpios = <&pio 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	timer {
+		clock-frequency = <12996791>;
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&eth {
+        status = "okay";
+
+        gmac0: mac@0 {
+                compatible = "mediatek,eth-mac";
+                reg = <0>;
+                phy-mode = "2500base-x";
+		local-mac-address = [000000000000];
+
+                fixed-link {
+                        speed = <2500>;
+                        full-duplex;
+                        pause;
+                };
+        };
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&phy0>;
+		local-mac-address = [000000000000];
+	};
+
+        mdio: mdio-bus {
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                phy0: ethernet-phy@0 {
+			compatible = "ethernet-phy-id03a2.9461";
+			reg = <0>;
+			phy-mode = "gmii";
+			#nvmem-cells = <&phy_calibration>;
+			#nvmem-cell-names = "phy-cal-data";
+                };
+
+		switch@1f {
+                        compatible = "mediatek,mt7531";
+                        reg = <31>;
+                        reset-gpios = <&pio 39 0>;
+
+                        ports {
+                                #address-cells = <1>;
+                                #size-cells = <0>;
+
+                                port@0 {
+                                        reg = <0>;
+                                        label = "lan1";
+                                };
+
+                                port@1 {
+                                        reg = <1>;
+                                        label = "lan2";
+                                };
+
+                                port@2 {
+                                        reg = <2>;
+                                        label = "lan3";
+                                };
+
+                                port@6 {
+                                        reg = <6>;
+                                        label = "cpu";
+                                        ethernet = <&gmac0>;
+                                        phy-mode = "2500base-x";
+
+                                        fixed-link {
+                                                speed = <2500>;
+                                                full-duplex;
+                                                pause;
+                                        };
+                                };
+                        };
+                };
+        };
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+	spi_nand: spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x400000>;
+				read-only;
+			};
+
+			partition@400000 {
+				label = "UBI_DEV";
+				reg = <0x400000 0x7c00000>;
+			};
+
+		};
+	};
+};
+
+&spi1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spic_pins>;
+	status = "disabled";
+};
+
+&pio {
+
+	i2c_pins: i2c-pins-g0 {
+                mux {
+                        function = "i2c";
+                        groups = "i2c0_0";
+                };
+        };
+
+        pcm_pins: pcm-pins-g0 {
+                mux {
+                        function = "pcm";
+                        groups = "pcm";
+                };
+        };
+
+        pwm0_pin: pwm0-pin-g0 {
+                mux {
+                        function = "pwm";
+                        groups = "pwm0_0";
+                };
+        };
+
+        pwm1_pin: pwm1-pin-g1 {
+                mux {
+                        function = "pwm";
+                        groups = "pwm1_1";
+                };
+        };
+
+        pwm2_pin: pwm2-pin {
+                mux {
+                        function = "pwm";
+                        groups = "pwm2";
+                };
+        };
+
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+
+	spic_pins: spi1-pins {
+		mux {
+			function = "spi";
+			groups = "spi1_1";
+		};
+	};
+
+	uart1_pins: uart1-pins-g1 {
+                mux {
+                        function = "uart";
+                        groups = "uart1_1";
+                };
+        };
+
+	uart2_pins: uart2-pins-g1 {
+		mux {
+                        function = "uart";
+                        groups = "uart2_1";
+                };
+        };
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm0_pin &pwm1_pin &pwm2_pin>;
+	interrupts = <GIC_SPI 137 IRQ_TYPE_LEVEL_HIGH>;
+	status = "disabled";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+};
+
+&xhci {
+	mediatek,u3p-dis-msk = <0x0>;
+	phys = <&u2port0 PHY_TYPE_USB2>,
+	       <&u3port0 PHY_TYPE_USB3>;
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -6,6 +6,9 @@ board=$(board_name)
 board_config_update
 
 case $board in
+asus,rt-ax52)
+	ucidef_set_led_netdev "eth1" "wan" "blue:wan" "eth1"
+	;;
 confiabits,mt7981)
 	ucidef_set_led_netdev "lan1" "lan1" "blue:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan2" "blue:lan-2" "lan2" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -14,6 +14,9 @@ mediatek_setup_interfaces()
 	acer,predator-w6)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 game" eth1
 		;;
+	asus,rt-ax52)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" eth1
+		;;
 	asus,tuf-ax4200|\
 	mediatek,mt7981-rfb|\
 	zbtlink,zbt-z8102ax)
@@ -94,6 +97,7 @@ mediatek_setup_macs()
 	local label_mac=""
 
 	case $board in
+	asus,rt-ax52|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax6000)
 		CI_UBIPART="UBI_DEV"

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -24,6 +24,10 @@ case "$FIRMWARE" in
 	;;
 "mediatek/mt7981_eeprom_mt7976_dbdc.bin")
 	case "$board" in
+	asus,rt-ax52)
+		CI_UBIPART="UBI_DEV"
+		caldata_extract_ubi "Factory" 0x0 0x1000
+		;;
 	cmcc,rax3000m)
 		case "$(cmdline_get_var root)" in
 		/dev/mmc*)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -16,6 +16,7 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && cat $key_path/6gMAC > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "2" ] && cat $key_path/5gMAC > /sys${DEVPATH}/macaddress
 		;;
+	asus,rt-ax52|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax6000)
 		CI_UBIPART="UBI_DEV"

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -10,6 +10,7 @@ preinit_set_mac_address() {
 		ip link set dev game address "$(cat $key_path/LANMAC)"
 		ip link set dev eth1 address "$(cat $key_path/WANMAC)"
 		;;
+	asus,rt-ax52|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax6000)
 		CI_UBIPART="UBI_DEV"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -60,6 +60,7 @@ platform_do_upgrade() {
 		CI_ROOTPART="rootfs"
 		emmc_do_upgrade "$1"
 		;;
+	asus,rt-ax52|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax6000)
 		CI_UBIPART="UBI_DEV"

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -207,6 +207,22 @@ define Device/asus_tuf-ax6000
 endef
 TARGET_DEVICES += asus_tuf-ax6000
 
+define Device/asus_rt-ax52
+  DEVICE_VENDOR := ASUS
+  DEVICE_MODEL := RT-AX52
+  DEVICE_DTS := mt7981b-asus-rt-ax52
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  DEVICE_PACKAGES := kmod-mt7981-firmware mt7981-wo-firmware
+  IMAGES := sysupgrade.bin
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb  with-initrd | pad-to 64k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += asus_rt-ax52
+
 define Device/bananapi_bpi-r3
   DEVICE_VENDOR := Bananapi
   DEVICE_MODEL := BPi-R3


### PR DESCRIPTION
Hardware
--------
SOC:   MediaTek MT7981b
RAM:   256MB DDR3
FLASH: 128MB SPI-NAND (Winbond W25N01GV)
WIFI:  Mediatek MT7981b DBDC 802.11ax 2.4/5 GHz
ETH:   MediaTek MT7531 Switch
UART:  3V3 115200 8N1 (Pinout silkscreened / Do not ocnnect VCC)

Installation
----------------------------------------------------------- Install openwrt image:
1. Download the OpenWrt initramfs image. Copy the image to a TFTP server reachable at 192.168.1.70/24. Rename the image to rtax52.bin.

2. Connect the PC with TFTP server to the RT-AX52. Set a static ip on the ethernet interface of your PC. (ip address: 192.168.1.70, subnet mask:255.255.255.0) Conect to the serial console, interrupt the autoboot process by pressing '4' when prompted.

3. Download & Boot the OpenWrt initramfs image.

   $ setenv ipaddr 192.168.1.1 $ setenv serverip 192.168.1.70 $ tftpboot 0x46000000 rtax52.bin $ bootm 0x46000000

4. Wait for OpenWrt to boot. Transfer the sysupgrade image to the device using scp and install using sysupgrade.

   $ sysupgrade -n <path-to-sysupgrade.bin> ---------------------------------------------------------------------------------- Revert to stock firmware:
1: Download the rt-ax52 firmware from ASUS official website. Save the firmware to tftp server directory and rename  to RT-AX52.trx

2: Connect the PC with TFTP server to the RT-AX52.
   Set a static ip on the ethernet interface of your PC.
     (ip address: 192.168.1.70, subnet mask:255.255.255.0)

3: Conect to the serial console,  power on again,  interrupt the autoboot process by pressing '4' when prompted.
  $: ubi remove linux
  $: ubi remove jffs2
  $: ubi remove rootfs
  $: ubi remove rootfs_data
  $: ubi create linux 0x45fe000
  $: reset
  then the dut will reboot,interrupt the autoboot process by pressing '2' when prompted.
            2: Load System code then write to Flash via TFTP.
             Warning!! Erase Linux in Flash then burn new one. Are you sure?(Y/N)
             $: enter y
  you will see the follow, type enter directly:
        Input device IP (192.168.1.1) ==:
        Input server IP (192.168.1.70) ==:
        Input Linux Kernel filename (RT-AX52.trx) ==:

4: wait for the device run up

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
